### PR TITLE
WIP: Exclude root types (Query, Mutation & Subscription) from wildcard import

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,28 +6,17 @@
   },
   "license": "MIT",
   "repository": "git@github.com:graphcool/graphql-import.git",
-  "files": [
-    "dist"
-  ],
+  "files": ["dist"],
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",
   "typescript": {
     "definition": "dist/index.d.ts"
   },
   "nyc": {
-    "extension": [
-      ".ts"
-    ],
-    "require": [
-      "ts-node/register"
-    ],
-    "include": [
-      "src/**/*.ts"
-    ],
-    "exclude": [
-      "**/*.d.ts",
-      "**/*.test.ts"
-    ],
+    "extension": [".ts"],
+    "require": ["ts-node/register"],
+    "include": ["src/**/*.ts"],
+    "exclude": ["**/*.d.ts", "**/*.test.ts"],
     "all": true,
     "sourceMap": true,
     "instrument": true
@@ -35,11 +24,15 @@
   "scripts": {
     "prepare": "npm run build",
     "build": "rm -rf dist && tsc -d",
-    "testlocal": "npm run build && nyc --reporter lcov --reporter text ava-ts --verbose src/**/*.test.ts",
-    "test-only": "npm run build && nyc --reporter lcov ava-ts --verbose src/**/*.test.ts --tap | tap-xunit > ~/reports/ava.xml",
+    "testlocal":
+      "npm run build && nyc --reporter lcov --reporter text ava-ts -u --verbose src/**/*.test.ts",
+    "test-only":
+      "npm run build && mkdir -p ~/reports && nyc --reporter lcov ava-ts --verbose src/**/*.test.ts --tap | tap-xunit > ~/reports/ava.xml",
     "test": "tslint src/**/*.ts && npm run test-only",
-    "docs": "typedoc --out docs src/index.ts --hideGenerator --exclude **/*.test.ts",
-    "docs:publish": "cp ./now.json ./docs && cd docs && now --public -f && now alias && now rm --yes --safe graphql-import & cd .."
+    "docs":
+      "typedoc --out docs src/index.ts --hideGenerator --exclude **/*.test.ts",
+    "docs:publish":
+      "cp ./now.json ./docs && cd docs && now --public -f && now alias && now rm --yes --safe graphql-import & cd .."
   },
   "peerDependencies": {
     "graphql": "^0.11.0 || ^0.12.0 || ^0.13.0"

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -183,7 +183,9 @@ test('importSchema: import all from objects', t => {
     }`
 
   const schemas = {
-    schemaA, schemaB, schemaC
+    schemaA,
+    schemaB,
+    schemaC,
   }
 
   const expectedSDL = `\
@@ -246,7 +248,7 @@ test(`importSchema: import all mix 'n match`, t => {
     }`
 
   const schemas = {
-    schemaB
+    schemaB,
   }
 
   const expectedSDL = `\
@@ -274,7 +276,6 @@ type C2 {
 })
 
 test(`importSchema: import all mix 'n match 2`, t => {
-
   const schemaA = `
     # import * from "fixtures/import-all/b.graphql"
 
@@ -360,7 +361,9 @@ test(`importSchema: import all - exclude Query/Mutation/Subscription type`, t =>
     }`
 
   const schemas = {
-    schemaA, schemaB, schemaC
+    schemaA,
+    schemaB,
+    schemaC,
   }
 
   const expectedSDL = `\
@@ -499,7 +502,10 @@ type B2 implements B {
   id: ID!
 }
 `
-  t.is(importSchema('fixtures/interfaces-implements-many/a.graphql'), expectedSDL)
+  t.is(
+    importSchema('fixtures/interfaces-implements-many/a.graphql'),
+    expectedSDL,
+  )
 })
 
 test('importSchema: input types', t => {
@@ -602,12 +608,12 @@ interface Node {
 
 test('root field imports', t => {
   const expectedSDL = `\
-type Dummy {
-  field: String
-}
-
 type Query {
   posts(filter: PostFilter): [Post]
+}
+
+type Dummy {
+  field: String
 }
 
 type Post {
@@ -624,14 +630,14 @@ input PostFilter {
 
 test('merged root field imports', t => {
   const expectedSDL = `\
-type Dummy {
-  field: String
-}
-
 type Query {
   helloA: String
   posts(filter: PostFilter): [Post]
   hello: String
+}
+
+type Dummy {
+  field: String
 }
 
 type Post {
@@ -666,36 +672,75 @@ type Shared {
 })
 
 test('missing type on type', t => {
-  const err = t.throws(() => importSchema('fixtures/type-not-found/a.graphql'), Error)
-  t.is(err.message, `Field test: Couldn't find type Post in any of the schemas.`)
+  const err = t.throws(
+    () => importSchema('fixtures/type-not-found/a.graphql'),
+    Error,
+  )
+  t.is(
+    err.message,
+    `Field test: Couldn't find type Post in any of the schemas.`,
+  )
 })
 
 test('missing type on interface', t => {
-  const err = t.throws(() => importSchema('fixtures/type-not-found/b.graphql'), Error)
-  t.is(err.message, `Field test: Couldn't find type Post in any of the schemas.`)
+  const err = t.throws(
+    () => importSchema('fixtures/type-not-found/b.graphql'),
+    Error,
+  )
+  t.is(
+    err.message,
+    `Field test: Couldn't find type Post in any of the schemas.`,
+  )
 })
 
 test('missing type on input type', t => {
-  const err = t.throws(() => importSchema('fixtures/type-not-found/c.graphql'), Error)
-  t.is(err.message, `Field post: Couldn't find type Post in any of the schemas.`)
+  const err = t.throws(
+    () => importSchema('fixtures/type-not-found/c.graphql'),
+    Error,
+  )
+  t.is(
+    err.message,
+    `Field post: Couldn't find type Post in any of the schemas.`,
+  )
 })
 
 test('missing interface type', t => {
-  const err = t.throws(() => importSchema('fixtures/type-not-found/d.graphql'), Error)
-  t.is(err.message, `Couldn't find interface MyInterface in any of the schemas.`)
+  const err = t.throws(
+    () => importSchema('fixtures/type-not-found/d.graphql'),
+    Error,
+  )
+  t.is(
+    err.message,
+    `Couldn't find interface MyInterface in any of the schemas.`,
+  )
 })
 
 test('missing union type', t => {
-  const err = t.throws(() => importSchema('fixtures/type-not-found/e.graphql'), Error)
+  const err = t.throws(
+    () => importSchema('fixtures/type-not-found/e.graphql'),
+    Error,
+  )
   t.is(err.message, `Couldn't find type C in any of the schemas.`)
 })
 
 test('missing type on input type', t => {
-  const err = t.throws(() => importSchema('fixtures/type-not-found/f.graphql'), Error)
-  t.is(err.message, `Field myfield: Couldn't find type Post in any of the schemas.`)
+  const err = t.throws(
+    () => importSchema('fixtures/type-not-found/f.graphql'),
+    Error,
+  )
+  t.is(
+    err.message,
+    `Field myfield: Couldn't find type Post in any of the schemas.`,
+  )
 })
 
 test('missing type on directive', t => {
-  const err = t.throws(() => importSchema('fixtures/type-not-found/g.graphql'), Error)
-  t.is(err.message, `Directive first: Couldn't find type first in any of the schemas.`)
+  const err = t.throws(
+    () => importSchema('fixtures/type-not-found/g.graphql'),
+    Error,
+  )
+  t.is(
+    err.message,
+    `Directive first: Couldn't find type first in any of the schemas.`,
+  )
 })

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -309,23 +309,86 @@ type C2 {
   t.is(importSchema(schemaA), expectedSDL)
 })
 
-test('importSchema: unions', t => {
+test(`importSchema: import all - exclude Query/Mutation/Subscription type`, t => {
+  const schemaC = `
+    type C1 {
+      id: ID!
+    }
+
+    type C2 {
+      id: ID!
+    }
+
+    type C3 {
+      id: ID!
+    }
+
+    type Query {
+      hello: String!
+    }
+
+    type Mutation {
+      hello: String!
+    }
+
+    type Subscription {
+      hello: String!
+    }
+    `
+
+  const schemaB = `
+    # import * from 'schemaC'
+
+    type B {
+      hello: String!
+      c1: C1
+      c2: C2
+    }`
+
+  const schemaA = `
+    # import B from 'schemaB'
+
+    type Query {
+      greet: String!
+    }
+
+    type A {
+      # test 1
+      first: String
+      second: Float
+      b: B
+    }`
+
+  const schemas = {
+    schemaA, schemaB, schemaC
+  }
+
   const expectedSDL = `\
+type Query {
+  greet: String!
+}
+
 type A {
+  first: String
+  second: Float
   b: B
 }
 
-union B = C1 | C2
+type B {
+  hello: String!
+  c1: C1
+  c2: C2
+}
 
 type C1 {
-  c1: ID
+  id: ID!
 }
 
 type C2 {
-  c2: ID
+  id: ID!
 }
 `
-  t.is(importSchema('fixtures/unions/a.graphql'), expectedSDL)
+  t.is(importSchema(schemaA, schemas), expectedSDL)
 })
 
 test('importSchema: scalar', t => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -274,7 +274,7 @@ function filterImportedDefinitions(
     ) {
       const previousTypeDefinitions: { [key: string]: DefinitionNode } = keyBy(
         flatten(allDefinitions.slice(0, allDefinitions.length - 1)).filter(
-          def => !rootFields.includes(def.name.value),
+          def => !includes(rootFields, def.name.value),
         ),
         def => def.name.value,
       )


### PR DESCRIPTION
It's a common scenario that you'd like to import all missing/referenced types in a schema except the root types (Query, Mutation & Subscription).

This PR so far adds a *failing* test case for this scenario but needs to be implemented before it can be merged.